### PR TITLE
Adding docker-compose setup.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+mongo:
+  image: mongo:latest
+
+postgres:
+  image: openmhealth/omh-postgres:latest
+
+authorization:
+  image: openmhealth/omh-dsu-authorization-server:latest
+  links:
+    - mongo:omh-mongo
+    - postgres:omh-postgres
+  ports:
+    - "8082:8082"
+
+resource:
+  image: openmhealth/omh-dsu-resource-server:latest
+  links:
+    - mongo:omh-mongo
+    - postgres:omh-postgres
+  ports:
+    - "8083:8083"

--- a/resources/rdbms/postgresql/Dockerfile
+++ b/resources/rdbms/postgresql/Dockerfile
@@ -1,0 +1,5 @@
+FROM postgres:latest
+MAINTAINER Matthew Schulkind <mschulkind@gmail.com>
+
+ADD oauth2-ddl.sql oauth2-sample-data.sql /docker-entrypoint-initdb.d/
+ADD db_init.sh /docker-entrypoint-initdb.d/

--- a/resources/rdbms/postgresql/db_init.sh
+++ b/resources/rdbms/postgresql/db_init.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+gosu postgres pg_ctl -w start
+gosu postgres psql -U postgres < /docker-entrypoint-initdb.d/oauth2-ddl.sql
+gosu postgres psql -U postgres omh < /docker-entrypoint-initdb.d/oauth2-sample-data.sql
+gosu postgres pg_ctl stop

--- a/resources/rdbms/postgresql/oauth2-sample-data.sql
+++ b/resources/rdbms/postgresql/oauth2-sample-data.sql
@@ -1,0 +1,16 @@
+INSERT INTO oauth_client_details (
+  client_id,
+  client_secret,
+  scope,
+  resource_ids,
+  authorized_grant_types,
+  authorities
+)
+VALUES (
+  'testClient',
+  'testClientSecret',
+  'read_data_points,write_data_points,delete_data_points',
+  'dataPoints',
+  'authorization_code,implicit,password,refresh_token',
+  'ROLE_CLIENT'
+);


### PR DESCRIPTION
I found the current setup process and container management a bit overwhelming. You'll probably want to reorganize this PR a bit, but with this, you can just clone this repo and then:

```
sudo pip install docker-compose
docker-compose up
```

Then just fire up postman (or the soon to be ruby client) and you're good to go.

This of course also assumes that you publish the omh-postgres image.